### PR TITLE
Setup Requires for loading rust

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,6 @@ import os
 import sys
 
 from setuptools import setup
-from setuptools.command.test import test as TestCommand
-from setuptools.command.sdist import sdist as SdistCommand
-
-try:
-    from setuptools_rust import RustExtension
-except ImportError:
-    import subprocess
-
-    errno = subprocess.call([sys.executable, "-m", "pip", "install", "setuptools-rust"])
-    if errno:
-        print("Please install setuptools-rust package")
-        raise SystemExit(errno)
-    else:
-        from setuptools_rust import RustExtension
-		
 
 from setuptools.command.install import install
 
@@ -120,10 +105,14 @@ class PostInstallCommand(install):
 
         # subprocess.check_call(["pytest", "tests"])
 
+def make_rust_extensions():
+    from setuptools_rust import RustExtension
+    return [RustExtension("rs_fec_conv.rs_fec_conv", "Cargo.toml", debug=True)]
+
 
 setup_requires = ["setuptools-rust>=0.10.1", "wheel"]
 install_requires = []
-#tests_require = install_requires + ["pytest", "pytest-benchmark"]
+tests_require = install_requires + ["pytest", "pytest-benchmark"]
 
 setup(
     name="rs_fec_conv",
@@ -144,7 +133,7 @@ setup(
         "Operating System :: MacOS :: MacOS X",
     ],
     packages=["rs_fec_conv"],
-    rust_extensions=[RustExtension("rs_fec_conv.rs_fec_conv", "Cargo.toml", debug=True)],
+    rust_extensions=make_rust_extensions(),
     install_requires=install_requires,
     tests_require=tests_require,
     setup_requires=setup_requires,

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,8 @@ import os
 import sys
 
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
+from setuptools.command.sdist import sdist as SdistCommand
 
 from setuptools.command.install import install
 


### PR DESCRIPTION
pip has a chicken and the egg problem; call a function after everything has been loaded by `setup.py` and then allow rust to start it's work

Accessing a subprocess for pip may have been possible for previous versions of pip, but newer releases work with a clean slate. After the requirements have been installed, the modules can be loaded safely.

Hope this helps!